### PR TITLE
feat: add comprehensive trailing spaces detection for all file types

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,5 @@
 # markdownlint configuration
 MD013: false  # Line length
 MD033: false  # Inline HTML
+MD009:        # Trailing spaces
+  "br_spaces": 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ The project uses a modern Turborepo monorepo stack with shared configurations:
 - **TailwindCSS + shadcn/ui**: Component library and styling system
 - **Shared Config Package**: Centralized ESLint, Prettier, TypeScript, and Tailwind configurations
 - **SQLite**: Local database with better-sqlite3 (migrating to Supabase)
-- **Development Tools**: ESLint with strict TypeScript rules, Prettier, markdownlint for code quality
+- **Development Tools**: ESLint with strict TypeScript rules and trailing spaces check, Prettier, markdownlint with trailing spaces validation for code quality
 
 ### Layout Architecture
 

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -8,7 +8,7 @@
 
 ### 1. 未使用依存関係の削除
 
-**影響**: バンドルサイズ増大、セキュリティリスク  
+**影響**: バンドルサイズ増大、セキュリティリスク
 **期待効果**: ~50MB以上のnode_modules削減
 
 **削除対象の依存関係**:
@@ -47,7 +47,7 @@
 
 ### 2. Hydration問題の修正 ✅
 
-**場所**: `apps/frontend/src/components/DarkModeToggle.tsx`  
+**場所**: `apps/frontend/src/components/DarkModeToggle.tsx`
 **問題**: サーバー・クライアント間の状態不一致によるhydration警告
 
 **修正済み**:
@@ -59,7 +59,7 @@
 
 ### 3. 型安全性の強化
 
-**場所**: 全ページコンポーネント  
+**場所**: 全ページコンポーネント
 **問題**: `locale as any`による unsafe なキャスト
 
 **現在のコード**:
@@ -75,7 +75,7 @@ if (!locales.includes(locale as any)) { // 危険なanyキャスト
 
 ### 4. ESLint設定の強化
 
-**現状**: 基本設定のみ（next/core-web-vitals）  
+**現状**: 基本設定のみ（next/core-web-vitals）
 **問題**: 1つの警告（img要素使用）が検出済み
 
 **追加すべき設定**:
@@ -100,7 +100,7 @@ if (!locales.includes(locale as any)) { // 危険なanyキャスト
 
 ### 5. 大規模コンポーネントの分割 🔄
 
-**場所**: `apps/frontend/src/app/[locale]/profile/page.tsx`（821行）  
+**場所**: `apps/frontend/src/app/[locale]/profile/page.tsx`（821行）
 **問題**: 単一コンポーネントが巨大すぎる
 
 **分割進捗**:
@@ -188,8 +188,8 @@ const { error, isError, handleError, clearError, executeAsync } = useErrorHandle
 
 #### 画像最適化
 
-**場所**: `apps/frontend/src/app/[locale]/profile/page.tsx:763`  
-**現在**: `<img>`タグ使用  
+**場所**: `apps/frontend/src/app/[locale]/profile/page.tsx:763`
+**現在**: `<img>`タグ使用
 **修正**: Next.js `<Image />`コンポーネントに変更
 
 ## 🔧 低優先度（品質向上）

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ハンズオン！Next.js+Hono+RPC+Supabase+Drizzle+pnpm+Turborepoで作るモノレポ構成のアプリ開発](https://zenn.dev/ippe/articles/7782e701f8df26)
 - [x] shadcn/uiを使うようにする
 - [x] docs/profile.mdを作成し、自分のプロフィール情報を記載する
 - [x] docs/profile.mdをもとにHomeやProfileページの内容を更新する
@@ -9,6 +10,16 @@
 - [x] お知らせはLinkedInの投稿やX、ブログはQiita, Zenn, note, Mediumなどに投稿するようにする
 - [x] Supabase, Vercel, Cloudflare WorkersはTerraformで構築できるみたいなので、Terraformを使うようにする。tfstateはcloudflare r2とかに保存する
 - [x] Turborepoを使うようにする
+- [ ] Claude Code Setup
+  - [ ] [MCP Server](https://docs.anthropic.com/ja/docs/claude-code/mcp)
+    - [開発でおすすめのMCP Server 一覧](https://zenn.dev/yareyare/articles/c5c07b64e7107f)
+    - [ ] [context7](https://github.com/upstash/context7)
+    - [ ] [github-mcp-server](https://github.com/github/github-mcp-server)
+    - [ ] [playwright-mcp](https://github.com/microsoft/playwright-mcp)
+    - [ ] [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch)
+    - [ ] [Browser MCP](https://github.com/browsermcp/mcp)
+    - [ ] [supabase-mcp](http://github.com/supabase-community/supabase-mcp)
+  - [ ] [devcontainer](https://docs.anthropic.com/ja/docs/claude-code/devcontainer)
 - [ ] リポジトリのリファクタリング
   - [ ] Phase1
   - [ ] Phase2（大規模コンポーネントの分割が完全には完了していないので続きをやる）

--- a/packages/config/eslint.js
+++ b/packages/config/eslint.js
@@ -16,6 +16,7 @@ module.exports = {
     "@typescript-eslint/prefer-optional-chain": "error",
     "jsx-a11y/alt-text": "error",
     "jsx-a11y/aria-props": "error",
-    "@next/next/no-img-element": "error"
+    "@next/next/no-img-element": "error",
+    "no-trailing-spaces": "error"
   },
 };


### PR DESCRIPTION
## Why
コードベース全体でtrailing spacesが混入しており、コード品質に影響していたため、包括的な検出・修正システムが必要でした。特にdocs/refactoring-plan.mdにtrailing spacesが存在していたにも関わらず、リントで検出されていませんでした。

## What & How
### ESLint設定強化
- `packages/config/eslint.js`に`no-trailing-spaces: "error"`ルールを追加
- TypeScript/JavaScriptファイルでtrailing spacesを厳密にチェック

### markdownlint設定修正
- `.markdownlint.yaml`でMD009ルールに`br_spaces: 0`設定を追加
- 単純な`MD009: true`では不十分だったため、明示的な設定を追加

### 既存trailing spacesの修正
- `docs/refactoring-plan.md`から7箇所のtrailing spacesを自動修正
- `pnpm run lint:fix`コマンドで一括修正

### ドキュメント更新
- `CLAUDE.md`のDevelopment Toolsセクションを更新し、trailing spaces検証機能を明記

## Note
- **根本原因**: markdownlintのMD009ルールはデフォルト設定では不十分で、`br_spaces`オプションの明示的設定が必要
- **検証方法**: `pnpm run lint`でTypeScript + Markdownの両方をチェック
- **自動修正**: `pnpm run lint:fix`で全ファイル種別のtrailing spacesを一括修正可能
- **影響範囲**: 既存コードに影響なし（品質向上のみ）

🤖 Generated with [Claude Code](https://claude.ai/code)